### PR TITLE
process log files with `/` in path correctly

### DIFF
--- a/write_output.py
+++ b/write_output.py
@@ -54,7 +54,7 @@ class TextOutput:
 
 
     def create_files(self):
-        dir_name = './stats_' + self.file_name
+        dir_name = './stats_' + self.file_name.replace(os.path.sep, '_')
         print(f"\nCreating files in directory '{dir_name}/'.")
         try:
             os.mkdir(dir_name)


### PR DESCRIPTION
Without replacing `/`, it tries to generate stats directories with multiple levels, failing to do so:

```
Creating files in directory './stats_/var/log/foreman/production.log/'.
Traceback (most recent call last):
  File "/root/evgeni/rails-load-stats-py/./rails-load-stats.py", line 189, in <module>
    main()
  File "/root/evgeni/rails-load-stats-py/./rails-load-stats.py", line 185, in main
    extraction.return_res()
  File "/root/evgeni/rails-load-stats-py/./rails-load-stats.py", line 148, in return_res
    self.output.write_duration_values_list(self.duration_values,
  File "/root/evgeni/rails-load-stats-py/write_output.py", line 130, in write_duration_values_list
    self.create_files()
  File "/root/evgeni/rails-load-stats-py/write_output.py", line 60, in create_files
    os.mkdir(dir_name)
FileNotFoundError: [Errno 2] No such file or directory: './stats_/var/log/foreman/production.log'
```

With this change, it places them in a sanitized directory:

```
Creating files in directory './stats__var_log_foreman_production.log/'.
```