### PR TITLE
Treat just completed tasks as done

### DIFF
--- a/rails-load-stats.py
+++ b/rails-load-stats.py
@@ -20,8 +20,8 @@ PROCESSING = {'attributes': {2: "Processing", 3: "by"},
               'communication_type_index': 4,
               'timestamp_index': 0,
               }
-TASK = {'attributes': {2: "Task"},
-        'min_line_len': 5,
+TASK = {'attributes': {2: "Task", 9: "state", 10: "changed:", 11: "stopped"},
+        'min_line_len': 13,
         }
 LINE_TYPE = (COMPLETED, PROCESSING, TASK)
 LINE_TYPE_NO = {}


### PR DESCRIPTION
Currently, we consider any task status change (e.g. planning->planned) as completed, which means requests triggering a task are skipped in statistics.